### PR TITLE
only notify when lights are on setting

### DIFF
--- a/app/src/main/java/de/j4velin/huenotifier/ColorFlashService.java
+++ b/app/src/main/java/de/j4velin/huenotifier/ColorFlashService.java
@@ -54,6 +54,7 @@ public class ColorFlashService extends IntentService {
                 api = APIHelper.getAPI(prefs);
                 int[] colors = intent.getIntArrayExtra("colors");
                 int[] lights = intent.getIntArrayExtra("lights");
+                final boolean flashOnlyIfLightsOn = intent.getBooleanExtra("flashOnlyIfLightsOn", true);
                 int size = Math.min(colors.length, lights.length);
                 for (int i = 0; i < size; i++) {
                     if (BuildConfig.DEBUG)
@@ -62,7 +63,7 @@ public class ColorFlashService extends IntentService {
                     new Thread(new Runnable() {
                         @Override
                         public void run() {
-                            doColorFlash(color, light);
+                            doColorFlash(color, light, flashOnlyIfLightsOn);
                         }
                     }).start();
                 }
@@ -73,7 +74,7 @@ public class ColorFlashService extends IntentService {
         }
     }
 
-    private void doColorFlash(final int color, final int light) {
+    private void doColorFlash(final int color, final int light, final boolean flashOnlyIfLightsOn) {
         synchronized (changing_lights) {
             while (changing_lights.contains(light)) {
                 try {
@@ -90,75 +91,77 @@ public class ColorFlashService extends IntentService {
                 if (BuildConfig.DEBUG)
                     Logger.log("current state: " + response.body());
                 final Light.LightState currentState = response.body().state;
-                Light.LightState alertState = new Light.LightState();
-                alertState.on = true;
-                alertState.xy =
-                        PHUtilities.calculateXY(color, response.body().modelid);
-                api.setLightState(light, alertState).enqueue(new Callback<List<JsonElement>>() {
-                    @Override
-                    public void onResponse(Call<List<JsonElement>> call,
-                                           Response<List<JsonElement>> response) {
-                        if (BuildConfig.DEBUG)
-                            Logger.log(
-                                    "set alert state response: " + Arrays
-                                            .toString(response.body().toArray()));
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                api.setLightState(light, currentState)
-                                        .enqueue(new Callback<List<JsonElement>>() {
-                                            @Override
-                                            public void onResponse(Call<List<JsonElement>> call,
-                                                                   Response<List<JsonElement>> response) {
-                                                if (BuildConfig.DEBUG)
-                                                    Logger.log(
-                                                            "revert state response: " + Arrays
-                                                                    .toString(response.body()
-                                                                            .toArray()));
-                                                done(light);
-                                            }
-
-                                            @Override
-                                            public void onFailure(Call<List<JsonElement>> call,
-                                                                  Throwable t) {
-                                                if (BuildConfig.DEBUG) {
-                                                    Logger.log("unable to restore original state:");
-                                                    Logger.log(t);
+                if(!flashOnlyIfLightsOn || currentState.on) {
+                    Light.LightState alertState = new Light.LightState();
+                    alertState.on = true;
+                    alertState.xy =
+                            PHUtilities.calculateXY(color, response.body().modelid);
+                    api.setLightState(light, alertState).enqueue(new Callback<List<JsonElement>>() {
+                        @Override
+                        public void onResponse(Call<List<JsonElement>> call,
+                                               Response<List<JsonElement>> response) {
+                            if (BuildConfig.DEBUG)
+                                Logger.log(
+                                        "set alert state response: " + Arrays
+                                                .toString(response.body().toArray()));
+                            new Handler().postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    api.setLightState(light, currentState)
+                                            .enqueue(new Callback<List<JsonElement>>() {
+                                                @Override
+                                                public void onResponse(Call<List<JsonElement>> call,
+                                                                       Response<List<JsonElement>> response) {
+                                                    if (BuildConfig.DEBUG)
+                                                        Logger.log(
+                                                                "revert state response: " + Arrays
+                                                                        .toString(response.body()
+                                                                                .toArray()));
+                                                    done(light);
                                                 }
-                                                // retry
-                                                api.setLightState(light, currentState)
-                                                        .enqueue(new Callback<List<JsonElement>>() {
-                                                            @Override
-                                                            public void onResponse(
-                                                                    Call<List<JsonElement>> call,
-                                                                    Response<List<JsonElement>> response) {
-                                                                done(light);
-                                                            }
 
-                                                            @Override
-                                                            public void onFailure(
-                                                                    Call<List<JsonElement>> call,
-                                                                    Throwable t) {
-                                                                if (BuildConfig.DEBUG)
-                                                                    Logger.log(t);
-                                                                done(light);
-                                                            }
-                                                        });
-                                            }
-                                        });
-                            }
-                        }, ALERT_STATE_DURATION);
-                    }
+                                                @Override
+                                                public void onFailure(Call<List<JsonElement>> call,
+                                                                      Throwable t) {
+                                                    if (BuildConfig.DEBUG) {
+                                                        Logger.log("unable to restore original state:");
+                                                        Logger.log(t);
+                                                    }
+                                                    // retry
+                                                    api.setLightState(light, currentState)
+                                                            .enqueue(new Callback<List<JsonElement>>() {
+                                                                @Override
+                                                                public void onResponse(
+                                                                        Call<List<JsonElement>> call,
+                                                                        Response<List<JsonElement>> response) {
+                                                                    done(light);
+                                                                }
 
-                    @Override
-                    public void onFailure(Call<List<JsonElement>> call, Throwable t) {
-                        if (BuildConfig.DEBUG) {
-                            Logger.log("unable to change to alert state:");
-                            Logger.log(t);
+                                                                @Override
+                                                                public void onFailure(
+                                                                        Call<List<JsonElement>> call,
+                                                                        Throwable t) {
+                                                                    if (BuildConfig.DEBUG)
+                                                                        Logger.log(t);
+                                                                    done(light);
+                                                                }
+                                                            });
+                                                }
+                                            });
+                                }
+                            }, ALERT_STATE_DURATION);
                         }
-                        done(light);
-                    }
-                });
+
+                        @Override
+                        public void onFailure(Call<List<JsonElement>> call, Throwable t) {
+                            if (BuildConfig.DEBUG) {
+                                Logger.log("unable to change to alert state:");
+                                Logger.log(t);
+                            }
+                            done(light);
+                        }
+                    });
+                }
             }
 
             @Override

--- a/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
+++ b/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
@@ -371,7 +371,8 @@ public class MainActivity extends AppCompatActivity {
                                                     startService(new Intent(MainActivity.this,
                                                             ColorFlashService.class)
                                                             .putExtra("lights", new int[]{tag[0]})
-                                                            .putExtra("colors", new int[]{color}));
+                                                            .putExtra("colors", new int[]{color})
+                                                            .putExtra("flashOnlyIfLightsOn", false));
                                                 }
                                             });
                                     dialog.show();
@@ -534,7 +535,8 @@ public class MainActivity extends AppCompatActivity {
                     final int itemPosition = ruleList.getChildLayoutPosition(cardView);
                     startService(new Intent(MainActivity.this, ColorFlashService.class).
                             putExtra("lights", rules.get(itemPosition).lights)
-                            .putExtra("colors", rules.get(itemPosition).colors));
+                            .putExtra("colors", rules.get(itemPosition).colors)
+                            .putExtra("flashOnlyIfLightsOn", false));
                 } else {
                     Snackbar.make(findViewById(android.R.id.content), R.string.not_connected,
                             Snackbar.LENGTH_SHORT).show();

--- a/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
+++ b/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
@@ -348,40 +348,38 @@ public class MainActivity extends AppCompatActivity {
 
                     for (Map.Entry<String, Light> entry : lights.entrySet()) {
                         Light light = entry.getValue();
+                        final LinearLayout cbLayout = new LinearLayout(linearLayout.getContext());
                         final CheckBox cb = new CheckBox(MainActivity.this);
-                        cb.setText(light.name);
+                        final TextView tv = new TextView(MainActivity.this);
+                        tv.setText(light.name);
                         final int[] tag = new int[2];
                         tag[0] = Integer.valueOf(entry.getKey());
+                        tag[1] = Color.WHITE;
                         cb.setTag(tag);
                         cb.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                             @Override
                             public void onCheckedChanged(CompoundButton compoundButton,
                                                          boolean isChecked) {
                                 if (isChecked) {
-                                    ColorPickerDialog dialog = new ColorPickerDialog(
-                                            MainActivity.this,
-                                            Color.WHITE);
-                                    dialog.setOnColorChangedListener(
-                                            new ColorPickerDialog.OnColorChangedListener() {
-                                                @Override
-                                                public void onColorChanged(int color) {
-                                                    cb.setTextColor(color);
-                                                    tag[1] = color;
-                                                    cb.setTag(tag);
-                                                    startService(new Intent(MainActivity.this,
-                                                            ColorFlashService.class)
-                                                            .putExtra("lights", new int[]{tag[0]})
-                                                            .putExtra("colors", new int[]{color})
-                                                            .putExtra("flashOnlyIfLightsOn", false));
-                                                }
-                                            });
-                                    dialog.show();
+                                    showColorPickerDialog(cb, tv, tag);
                                 } else {
-                                    cb.setTextColor(Color.WHITE);
+                                    tv.setTextColor(tag[1]);
                                 }
                             }
                         });
-                        linearLayout.addView(cb);
+                        tv.setOnClickListener(new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                if(!cb.isChecked()) {
+                                    cb.setChecked(true);
+                                } else {
+                                    showColorPickerDialog(cb, tv, tag);
+                                }
+                            }
+                        });
+                        cbLayout.addView(cb);
+                        cbLayout.addView(tv);
+                        linearLayout.addView(cbLayout);
                         checkBoxes.add(cb);
                     }
                     new AlertDialog.Builder(MainActivity.this).setView(v).
@@ -422,6 +420,27 @@ public class MainActivity extends AppCompatActivity {
                 }
             }).execute();
         }
+    }
+
+    private void showColorPickerDialog(final CheckBox cb, final TextView tv, final int[] tag) {
+        ColorPickerDialog dialog = new ColorPickerDialog(
+                MainActivity.this,
+                tag[1]);
+        dialog.setOnColorChangedListener(
+                new ColorPickerDialog.OnColorChangedListener() {
+                    @Override
+                    public void onColorChanged(int color) {
+                        tv.setTextColor(color);
+                        tag[1] = color;
+                        cb.setTag(tag);
+                        startService(new Intent(MainActivity.this,
+                                ColorFlashService.class)
+                                .putExtra("lights", new int[]{tag[0]})
+                                .putExtra("colors", new int[]{color})
+                                .putExtra("flashOnlyIfLightsOn", false));
+                    }
+                });
+        dialog.show();
     }
 
     private void connectToBridge() {

--- a/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
+++ b/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
@@ -318,6 +318,17 @@ public class MainActivity extends AppCompatActivity {
         ruleList.setAdapter(ruleAdapter);
     }
 
+    private void editRule(Rule rule) {
+        if (lights == null) {
+            getLights();
+            Snackbar.make(findViewById(android.R.id.content),
+                    "No lights found yet - please wait...",
+                    Snackbar.LENGTH_LONG).show();
+        } else {
+            showEditRuleDialog(rule);
+        }
+    }
+
     private void addRule() {
         if (lights == null) {
             getLights();
@@ -328,98 +339,109 @@ public class MainActivity extends AppCompatActivity {
             new AppPicker(MainActivity.this, new AppPicker.AppPickListener() {
                 @Override
                 public void appSelected(final AppPicker.AppData app) {
-
-                    final List<CheckBox> checkBoxes = new ArrayList<CheckBox>(lights.size());
-
-                    View v = getLayoutInflater().inflate(R.layout.rule_add, null);
-                    TextView appName = (TextView) v.findViewById(R.id.app);
-                    appName.setText(app.name);
-
-                    TextView person = (TextView) v.findViewById(R.id.person);
-                    Spinner people = (Spinner) v.findViewById(R.id.people);
-                    if (Build.VERSION.SDK_INT >= 19 && BuildConfig.DEBUG) {
-                        // TODO: fill spinner
-                    } else {
-                        person.setVisibility(View.GONE);
-                        people.setVisibility(View.GONE);
-                    }
-
-                    LinearLayout linearLayout = (LinearLayout) v.findViewById(R.id.lights);
-
-                    for (Map.Entry<String, Light> entry : lights.entrySet()) {
-                        Light light = entry.getValue();
-                        final LinearLayout cbLayout = new LinearLayout(linearLayout.getContext());
-                        final CheckBox cb = new CheckBox(MainActivity.this);
-                        final TextView tv = new TextView(MainActivity.this);
-                        tv.setText(light.name);
-                        final int[] tag = new int[2];
-                        tag[0] = Integer.valueOf(entry.getKey());
-                        tag[1] = Color.WHITE;
-                        cb.setTag(tag);
-                        cb.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                            @Override
-                            public void onCheckedChanged(CompoundButton compoundButton,
-                                                         boolean isChecked) {
-                                if (isChecked) {
-                                    showColorPickerDialog(cb, tv, tag);
-                                } else {
-                                    tv.setTextColor(tag[1]);
-                                }
-                            }
-                        });
-                        tv.setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                if(!cb.isChecked()) {
-                                    cb.setChecked(true);
-                                } else {
-                                    showColorPickerDialog(cb, tv, tag);
-                                }
-                            }
-                        });
-                        cbLayout.addView(cb);
-                        cbLayout.addView(tv);
-                        linearLayout.addView(cbLayout);
-                        checkBoxes.add(cb);
-                    }
-                    new AlertDialog.Builder(MainActivity.this).setView(v).
-                            setPositiveButton(android.R.string.ok,
-                                    new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(DialogInterface dialogInterface,
-                                                            int i) {
-                                            String lights = null;
-                                            String colors = null;
-                                            for (CheckBox cb : checkBoxes) {
-                                                if (cb.isChecked()) {
-                                                    if (lights == null) {
-                                                        lights = String
-                                                                .valueOf(((int[]) cb.getTag())[0]);
-                                                        colors = String
-                                                                .valueOf(((int[]) cb.getTag())[1]);
-                                                    } else {
-                                                        lights += "," + ((int[]) cb.getTag())[0];
-                                                        colors += "," + ((int[]) cb.getTag())[1];
-                                                    }
-                                                }
-                                            }
-                                            dialogInterface.dismiss();
-                                            Database db = Database.getInstance(MainActivity.this);
-                                            db.insert(app.name, app.pkg, null, lights, colors);
-                                            rules.add(db.getRule(app.pkg, null));
-                                            db.close();
-                                            ruleAdapter.notifyDataSetChanged();
-                                        }
-                                    }).setNegativeButton(android.R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialogInterface, int i) {
-                                    dialogInterface.cancel();
-                                }
-                            }).create().show();
+                    Rule rule = new Rule(app.name, app.pkg, null, new int[0], new int[0]);
+                    showEditRuleDialog(rule);
                 }
             }).execute();
         }
+    }
+
+    private void showEditRuleDialog(final Rule rule) {
+        final List<CheckBox> checkBoxes = new ArrayList<CheckBox>(lights.size());
+
+        View v = getLayoutInflater().inflate(R.layout.rule_add, null);
+        TextView appName = (TextView) v.findViewById(R.id.app);
+        appName.setText(rule.appName);
+
+        TextView person = (TextView) v.findViewById(R.id.person);
+        Spinner people = (Spinner) v.findViewById(R.id.people);
+        if (Build.VERSION.SDK_INT >= 19 && BuildConfig.DEBUG) {
+            // TODO: fill spinner
+        } else {
+            person.setVisibility(View.GONE);
+            people.setVisibility(View.GONE);
+        }
+
+        LinearLayout linearLayout = (LinearLayout) v.findViewById(R.id.lights);
+
+        for (Map.Entry<String, Light> entry : lights.entrySet()) {
+            Light light = entry.getValue();
+            final int[] tag = new int[2];
+            tag[0] = Integer.valueOf(entry.getKey());
+            tag[1] = rule.getColor(tag[0]);
+
+            final LinearLayout cbLayout = new LinearLayout(linearLayout.getContext());
+            final CheckBox cb = new CheckBox(MainActivity.this);
+            final TextView tv = new TextView(MainActivity.this);
+            tv.setText(light.name);
+            tv.setTextColor(tag[1]);
+            cb.setTag(tag);
+            cb.setChecked(rule.contains(tag[0]));
+            cb.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton,
+                                             boolean isChecked) {
+                    if (isChecked) {
+                        showColorPickerDialog(cb, tv, tag);
+                    } else {
+                        tv.setTextColor(tag[1]);
+                    }
+                }
+            });
+            tv.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if(!cb.isChecked()) {
+                        cb.setChecked(true);
+                    } else {
+                        showColorPickerDialog(cb, tv, tag);
+                    }
+                }
+            });
+            cbLayout.addView(cb);
+            cbLayout.addView(tv);
+            linearLayout.addView(cbLayout);
+            checkBoxes.add(cb);
+        }
+        new AlertDialog.Builder(MainActivity.this).setView(v).
+                setPositiveButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface,
+                                                int i) {
+                                String lights = null;
+                                String colors = null;
+                                for (CheckBox cb : checkBoxes) {
+                                    if (cb.isChecked()) {
+                                        if (lights == null) {
+                                            lights = String
+                                                    .valueOf(((int[]) cb.getTag())[0]);
+                                            colors = String
+                                                    .valueOf(((int[]) cb.getTag())[1]);
+                                        } else {
+                                            lights += "," + ((int[]) cb.getTag())[0];
+                                            colors += "," + ((int[]) cb.getTag())[1];
+                                        }
+                                    }
+                                }
+                                dialogInterface.dismiss();
+                                Database db = Database.getInstance(MainActivity.this);
+                                if(db.contains(rule.appPkg)) {
+                                    db.delete(rule.appPkg, rule.person);
+                                    rules.remove(rule);
+                                }
+                                db.insert(rule.appName, rule.appPkg, null, lights, colors);
+                                rules.add(db.getRule(rule.appPkg, null));
+                                db.close();
+                                ruleAdapter.notifyDataSetChanged();
+                            }
+                        }).setNegativeButton(android.R.string.cancel,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        dialogInterface.cancel();
+                    }
+                }).create().show();
     }
 
     private void showColorPickerDialog(final CheckBox cb, final TextView tv, final int[] tag) {
@@ -531,6 +553,24 @@ public class MainActivity extends AppCompatActivity {
             this.appPkg = appPkg;
             this.person = person;
         }
+
+        public int getColor(int lightId) {
+            for(int i = 0; i < lights.length; i++) {
+                if(lights[i] == lightId) {
+                    return colors[i];
+                }
+            }
+            return Color.WHITE;
+        }
+
+        public boolean contains(int lightId) {
+            for(int i = 0; i < lights.length; i++) {
+                if(lights[i] == lightId) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     private class RuleAdapter extends RecyclerView.Adapter<RuleAdapter.ViewHolder> {
@@ -543,6 +583,21 @@ public class MainActivity extends AppCompatActivity {
                 View edit = view.findViewById(R.id.edit);
                 edit.setMinimumHeight(view.findViewById(R.id.lights).getHeight());
                 fadeView(true, edit);
+            }
+        };
+        private final View.OnClickListener configureClickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                View editView = (View) view.getParent();
+                if (isConnected) {
+                    View cardView = (View) editView.getParent();
+                    final int itemPosition = ruleList.getChildLayoutPosition(cardView);
+                    editRule(rules.get(itemPosition));
+                } else {
+                    Snackbar.make(findViewById(android.R.id.content), R.string.not_connected,
+                            Snackbar.LENGTH_SHORT).show();
+                }
+                fadeView(false, editView);
             }
         };
         private final View.OnClickListener testClickListener = new View.OnClickListener() {
@@ -588,6 +643,7 @@ public class MainActivity extends AppCompatActivity {
             View v = inflater.inflate(rule, parent, false);
             v.setOnClickListener(clickListener);
             ViewHolder holder = new ViewHolder(v);
+            holder.edit.findViewById(R.id.configure).setOnClickListener(configureClickListener);
             holder.edit.findViewById(R.id.test).setOnClickListener(testClickListener);
             holder.edit.findViewById(R.id.delete).setOnClickListener(deleteClickListener);
             holder.edit.findViewById(R.id.cancel).setOnClickListener(cancelClickListener);

--- a/app/src/main/java/de/j4velin/huenotifier/NotificationListener.java
+++ b/app/src/main/java/de/j4velin/huenotifier/NotificationListener.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 public class NotificationListener extends NotificationListenerService {
 
     private final static long TIME_THRESHOLD = 1000;
-    private static boolean ignoreOnGoing = true, ignoreLowPriority = true;
+    private static boolean ignoreOnGoing = true, ignoreLowPriority = true, flashOnlyIfLightsOn = true;
     private long lastTime = 0L;
     private String lastPackage = null;
 
@@ -40,6 +40,7 @@ public class NotificationListener extends NotificationListenerService {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
         ignoreOnGoing = prefs.getBoolean("ignoreOnGoing", true);
         ignoreLowPriority = prefs.getBoolean("ignoreLowPriority", true);
+        flashOnlyIfLightsOn = prefs.getBoolean("flashOnlyIfLightsOn", true);
     }
 
     @Override
@@ -95,7 +96,8 @@ public class NotificationListener extends NotificationListenerService {
                     String pattern = db.getPattern(lastPackage, people);
                     startService(new Intent(this, ColorFlashService.class)
                             .putExtra("lights", Util.getLights(pattern))
-                            .putExtra("colors", Util.getColors(pattern)));
+                            .putExtra("colors", Util.getColors(pattern))
+                            .putExtra("flashOnlyIfLightsOn", flashOnlyIfLightsOn));
                 }
                 db.close();
             } else if (BuildConfig.DEBUG) {

--- a/app/src/main/res/drawable/ic_settings_24dp.xml
+++ b/app/src/main/res/drawable/ic_settings_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2015 The Android Open Source Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="48.0"
+        android:viewportHeight="48.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M38.86 25.95c.08,-.64.14,-1.29.14,-1.95s-.06,-1.31,-.14,-1.95l4.23,-3.31c.38,-.3.49,-.84.24,-1.28l-4,-6.93c-.25,-.43,-.77,-.61,-1.22,-.43l-4.98 2.01c-1.03,-.79,-2.16,-1.46,-3.38,-1.97L29 4.84c-.09,-.47,-.5,-.84,-1,-.84h-8c-.5 0,-.91.37,-.99.84l-.75 5.3c-1.22.51,-2.35 1.17,-3.38 1.97L9.9 10.1c-.45,-.17,-.97 0,-1.22.43l-4 6.93c-.25.43,-.14.97.24 1.28l4.22 3.31C9.06 22.69 9 23.34 9 24s.06 1.31.14 1.95l-4.22 3.31c-.38.3,-.49.84,-.24 1.28l4 6.93c.25.43.77.61 1.22.43l4.98,-2.01c1.03.79 2.16 1.46 3.38 1.97l.75 5.3c.08.47.49.84.99.84h8c.5 0 .91,-.37.99,-.84l.75,-5.3c1.22,-.51 2.35,-1.17 3.38,-1.97l4.98 2.01c.45.17.97 0 1.22,-.43l4,-6.93c.25,-.43.14,-.97,-.24,-1.28l-4.22,-3.31zM24 31c-3.87 0,-7,-3.13,-7,-7s3.13,-7 7,-7 7 3.13 7 7,-3.13 7,-7 7z"/>
+</vector>

--- a/app/src/main/res/layout/light_box.xml
+++ b/app/src/main/res/layout/light_box.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentStart="true"
+    android:orientation="horizontal" >
+
+</LinearLayout>

--- a/app/src/main/res/layout/rule.xml
+++ b/app/src/main/res/layout/rule.xml
@@ -34,6 +34,18 @@
         android:visibility="gone">
 
         <TextView
+            android:id="@+id/configure"
+            android:layout_width="0dip"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:drawablePadding="5dp"
+            android:drawableStart="@drawable/ic_settings_24dp"
+            android:drawableTint="#fff"
+            android:gravity="center_vertical"
+            android:padding="10dp"
+            android:text="Edit" />
+
+        <TextView
             android:id="@+id/test"
             android:layout_width="0dip"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/rule_add.xml
+++ b/app/src/main/res/layout/rule_add.xml
@@ -33,4 +33,5 @@
         android:layout_alignParentStart="true"
         android:layout_below="@id/people"
         android:orientation="vertical" />
+
 </RelativeLayout>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -8,5 +8,9 @@
         android:defaultValue="true"
         android:key="ignoreLowPriority"
         android:title="Ignore low priority notifications" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="flashOnlyIfLightsOn"
+        android:title="Flash notifications only if lights are on" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Hue lights are expected to last 50'000 on/off switches.
Because one can expect a lot of notifications and in order to preserve life expectancy I propose an additional setting to flash notifications only on bulbs that are already on.
Also this new option would allow to disable notifications flashing during night.