### PR TITLE
only notify when lights are on setting

### DIFF
--- a/app/src/main/java/de/j4velin/huenotifier/ColorFlashService.java
+++ b/app/src/main/java/de/j4velin/huenotifier/ColorFlashService.java
@@ -54,6 +54,7 @@ public class ColorFlashService extends IntentService {
                 api = APIHelper.getAPI(prefs);
                 int[] colors = intent.getIntArrayExtra("colors");
                 int[] lights = intent.getIntArrayExtra("lights");
+                final boolean flashOnlyIfLightsOn = intent.getBooleanExtra("flashOnlyIfLightsOn", true);
                 int size = Math.min(colors.length, lights.length);
                 for (int i = 0; i < size; i++) {
                     if (BuildConfig.DEBUG)
@@ -62,7 +63,7 @@ public class ColorFlashService extends IntentService {
                     new Thread(new Runnable() {
                         @Override
                         public void run() {
-                            doColorFlash(color, light);
+                            doColorFlash(color, light, flashOnlyIfLightsOn);
                         }
                     }).start();
                 }
@@ -73,7 +74,7 @@ public class ColorFlashService extends IntentService {
         }
     }
 
-    private void doColorFlash(final int color, final int light) {
+    private void doColorFlash(final int color, final int light, final boolean flashOnlyIfLightsOn) {
         synchronized (changing_lights) {
             while (changing_lights.contains(light)) {
                 try {
@@ -90,75 +91,77 @@ public class ColorFlashService extends IntentService {
                 if (BuildConfig.DEBUG)
                     Logger.log("current state: " + response.body());
                 final Light.LightState currentState = response.body().state;
-                Light.LightState alertState = new Light.LightState();
-                alertState.on = true;
-                alertState.xy =
-                        PHUtilities.calculateXY(color, response.body().modelid);
-                api.setLightState(light, alertState).enqueue(new Callback<List<JsonElement>>() {
-                    @Override
-                    public void onResponse(Call<List<JsonElement>> call,
-                                           Response<List<JsonElement>> response) {
-                        if (BuildConfig.DEBUG)
-                            Logger.log(
-                                    "set alert state response: " + Arrays
-                                            .toString(response.body().toArray()));
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                api.setLightState(light, currentState)
-                                        .enqueue(new Callback<List<JsonElement>>() {
-                                            @Override
-                                            public void onResponse(Call<List<JsonElement>> call,
-                                                                   Response<List<JsonElement>> response) {
-                                                if (BuildConfig.DEBUG)
-                                                    Logger.log(
-                                                            "revert state response: " + Arrays
-                                                                    .toString(response.body()
-                                                                            .toArray()));
-                                                done(light);
-                                            }
-
-                                            @Override
-                                            public void onFailure(Call<List<JsonElement>> call,
-                                                                  Throwable t) {
-                                                if (BuildConfig.DEBUG) {
-                                                    Logger.log("unable to restore original state:");
-                                                    Logger.log(t);
+                if(!flashOnlyIfLightsOn || currentState.on) {
+                    Light.LightState alertState = new Light.LightState();
+                    alertState.on = true;
+                    alertState.xy =
+                            PHUtilities.calculateXY(color, response.body().modelid);
+                    api.setLightState(light, alertState).enqueue(new Callback<List<JsonElement>>() {
+                        @Override
+                        public void onResponse(Call<List<JsonElement>> call,
+                                               Response<List<JsonElement>> response) {
+                            if (BuildConfig.DEBUG)
+                                Logger.log(
+                                        "set alert state response: " + Arrays
+                                                .toString(response.body().toArray()));
+                            new Handler().postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    api.setLightState(light, currentState)
+                                            .enqueue(new Callback<List<JsonElement>>() {
+                                                @Override
+                                                public void onResponse(Call<List<JsonElement>> call,
+                                                                       Response<List<JsonElement>> response) {
+                                                    if (BuildConfig.DEBUG)
+                                                        Logger.log(
+                                                                "revert state response: " + Arrays
+                                                                        .toString(response.body()
+                                                                                .toArray()));
+                                                    done(light);
                                                 }
-                                                // retry
-                                                api.setLightState(light, currentState)
-                                                        .enqueue(new Callback<List<JsonElement>>() {
-                                                            @Override
-                                                            public void onResponse(
-                                                                    Call<List<JsonElement>> call,
-                                                                    Response<List<JsonElement>> response) {
-                                                                done(light);
-                                                            }
 
-                                                            @Override
-                                                            public void onFailure(
-                                                                    Call<List<JsonElement>> call,
-                                                                    Throwable t) {
-                                                                if (BuildConfig.DEBUG)
-                                                                    Logger.log(t);
-                                                                done(light);
-                                                            }
-                                                        });
-                                            }
-                                        });
-                            }
-                        }, ALERT_STATE_DURATION);
-                    }
+                                                @Override
+                                                public void onFailure(Call<List<JsonElement>> call,
+                                                                      Throwable t) {
+                                                    if (BuildConfig.DEBUG) {
+                                                        Logger.log("unable to restore original state:");
+                                                        Logger.log(t);
+                                                    }
+                                                    // retry
+                                                    api.setLightState(light, currentState)
+                                                            .enqueue(new Callback<List<JsonElement>>() {
+                                                                @Override
+                                                                public void onResponse(
+                                                                        Call<List<JsonElement>> call,
+                                                                        Response<List<JsonElement>> response) {
+                                                                    done(light);
+                                                                }
 
-                    @Override
-                    public void onFailure(Call<List<JsonElement>> call, Throwable t) {
-                        if (BuildConfig.DEBUG) {
-                            Logger.log("unable to change to alert state:");
-                            Logger.log(t);
+                                                                @Override
+                                                                public void onFailure(
+                                                                        Call<List<JsonElement>> call,
+                                                                        Throwable t) {
+                                                                    if (BuildConfig.DEBUG)
+                                                                        Logger.log(t);
+                                                                    done(light);
+                                                                }
+                                                            });
+                                                }
+                                            });
+                                }
+                            }, ALERT_STATE_DURATION);
                         }
-                        done(light);
-                    }
-                });
+
+                        @Override
+                        public void onFailure(Call<List<JsonElement>> call, Throwable t) {
+                            if (BuildConfig.DEBUG) {
+                                Logger.log("unable to change to alert state:");
+                                Logger.log(t);
+                            }
+                            done(light);
+                        }
+                    });
+                }
             }
 
             @Override

--- a/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
+++ b/app/src/main/java/de/j4velin/huenotifier/MainActivity.java
@@ -371,7 +371,8 @@ public class MainActivity extends AppCompatActivity {
                                                     startService(new Intent(MainActivity.this,
                                                             ColorFlashService.class)
                                                             .putExtra("lights", new int[]{tag[0]})
-                                                            .putExtra("colors", new int[]{color}));
+                                                            .putExtra("colors", new int[]{color})
+                                                            .putExtra("flashOnlyIfLightsOn", false));
                                                 }
                                             });
                                     dialog.show();
@@ -534,7 +535,8 @@ public class MainActivity extends AppCompatActivity {
                     final int itemPosition = ruleList.getChildLayoutPosition(cardView);
                     startService(new Intent(MainActivity.this, ColorFlashService.class).
                             putExtra("lights", rules.get(itemPosition).lights)
-                            .putExtra("colors", rules.get(itemPosition).colors));
+                            .putExtra("colors", rules.get(itemPosition).colors)
+                            .putExtra("flashOnlyIfLightsOn", false));
                 } else {
                     Snackbar.make(findViewById(android.R.id.content), R.string.not_connected,
                             Snackbar.LENGTH_SHORT).show();

--- a/app/src/main/java/de/j4velin/huenotifier/NotificationListener.java
+++ b/app/src/main/java/de/j4velin/huenotifier/NotificationListener.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 public class NotificationListener extends NotificationListenerService {
 
     private final static long TIME_THRESHOLD = 1000;
-    private static boolean ignoreOnGoing = true, ignoreLowPriority = true;
+    private static boolean ignoreOnGoing = true, ignoreLowPriority = true, flashOnlyIfLightsOn = true;
     private long lastTime = 0L;
     private String lastPackage = null;
 
@@ -40,6 +40,7 @@ public class NotificationListener extends NotificationListenerService {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
         ignoreOnGoing = prefs.getBoolean("ignoreOnGoing", true);
         ignoreLowPriority = prefs.getBoolean("ignoreLowPriority", true);
+        flashOnlyIfLightsOn = prefs.getBoolean("flashOnlyIfLightsOn", true);
     }
 
     @Override
@@ -95,7 +96,8 @@ public class NotificationListener extends NotificationListenerService {
                     String pattern = db.getPattern(lastPackage, people);
                     startService(new Intent(this, ColorFlashService.class)
                             .putExtra("lights", Util.getLights(pattern))
-                            .putExtra("colors", Util.getColors(pattern)));
+                            .putExtra("colors", Util.getColors(pattern))
+                            .putExtra("flashOnlyIfLightsOn", flashOnlyIfLightsOn));
                 }
                 db.close();
             } else if (BuildConfig.DEBUG) {

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -8,5 +8,9 @@
         android:defaultValue="true"
         android:key="ignoreLowPriority"
         android:title="Ignore low priority notifications" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="flashOnlyIfLightsOn"
+        android:title="Flash notifications only if lights are on" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Hue lights are expected to last 50'000 on/off switches.
Because one can expect a lot of notifications and in order to preserve life expectancy I propose an additional setting to flash notifications only on bulbs that are already on.
Also this new option would allow to disable notifications flashing during night.